### PR TITLE
Redb backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,6 +95,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
 
 [[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -153,12 +165,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake3"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3888aaa89e4b2a40fca9848e400f6a658a5a3978de7be858e209cafa8be9a4a0"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if 1.0.0",
+ "constant_time_eq",
+]
+
+[[package]]
 name = "blk-archive"
 version = "0.1.0"
 dependencies = [
  "anyhow",
  "atty",
  "blake2",
+ "blake3",
  "byteorder",
  "chrono",
  "clap",
@@ -321,6 +347,12 @@ dependencies = [
  "unicode-width",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "core-foundation-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,15 +156,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
 
 [[package]]
-name = "blake2"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
-dependencies = [
- "digest",
-]
-
-[[package]]
 name = "blake3"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -183,15 +174,16 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "atty",
- "blake2",
  "blake3",
  "byteorder",
  "chrono",
  "clap",
  "devicemapper 0.34.4 (git+https://github.com/stratis-storage/devicemapper-rs?branch=master)",
  "duct",
+ "fastrand",
  "gearhash",
  "generic-array",
+ "indexmap",
  "libc",
  "linked-hash-map",
  "lru",
@@ -200,6 +192,7 @@ dependencies = [
  "num_enum",
  "rand",
  "rand_chacha",
+ "redb",
  "roaring",
  "serde",
  "serde_json",
@@ -210,15 +203,6 @@ dependencies = [
  "udev 0.9.3",
  "walkdir",
  "zstd",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
 ]
 
 [[package]]
@@ -379,16 +363,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-common"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
-dependencies = [
- "generic-array",
- "typenum",
-]
-
-[[package]]
 name = "data-encoding"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -447,17 +421,6 @@ source = "git+https://github.com/stratis-storage/devicemapper-rs?branch=master#d
 dependencies = [
  "bindgen",
  "pkg-config",
-]
-
-[[package]]
-name = "digest"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
-dependencies = [
- "block-buffer",
- "crypto-common",
- "subtle",
 ]
 
 [[package]]
@@ -757,9 +720,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "libloading"
@@ -1018,6 +981,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60fcc7d6849342eff22c4350c8b9a989ee8ceabc4b481253e8946b9fe83d684"
 
 [[package]]
+name = "redb"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fefa3e5ff4a369819c3d6df4195873d6f9abad109f13c0d505dbe119cfabb10"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "regex"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1197,12 +1169,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
-name = "subtle"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
-
-[[package]]
 name = "syn"
 version = "2.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1308,9 +1274,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "udev"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 anyhow = "1.0"
 atty = "0.2"
 blake2 = "0.10"
+blake3 = "1"
 byteorder = "1.4"
 chrono = "0.4"
 clap = { version = "4.5.26", features = ["cargo", "env"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ serde_json = "1.0.96"
 libc = "0.2"
 linked-hash-map = "0.5.6"
 lru = "0.12.5"
-nix = "0.29"
+nix = { version = "0.29", features = ["ioctl"] }
 nom = "7.1"
 num_enum = "0.7.3"
 rand = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0"
 atty = "0.2"
-blake2 = "0.10"
 blake3 = "1"
 byteorder = "1.4"
 chrono = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ clap = { version = "4.5.26", features = ["cargo", "env"] }
 devicemapper = { git = "https://github.com/stratis-storage/devicemapper-rs", branch = "master" }
 gearhash = "0.1.3"
 generic-array = "0.14"
+indexmap = "2"
 serde_json = "1.0.96"
 libc = "0.2"
 linked-hash-map = "0.5.6"
@@ -24,6 +25,7 @@ nom = "7.1"
 num_enum = "0.7.3"
 rand = "0.8"
 rand_chacha = "0.3"
+redb = "3"
 roaring = "0.10.10"
 serde = { version = "1", features = ["derive"] }
 serde_yaml_ng = "0.10"
@@ -35,6 +37,7 @@ walkdir = "2"
 zstd = "0.13.2"
 
 [dev-dependencies]
+fastrand = "2"
 duct = "0.13"
 serde_json = "1.0"
 tempfile = "3.16"

--- a/src/archive/data.rs
+++ b/src/archive/data.rs
@@ -1,0 +1,53 @@
+use anyhow::Result;
+
+use crate::iovec::*;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+use crate::archive::file_based::Data;
+use crate::archive::redb_based::DedupStore;
+use crate::hash::*;
+use crate::slab::SlabFile;
+
+pub trait Store {
+    fn data_add(&mut self, h: Hash256, iov: &IoVec, len: u64) -> Result<((u32, u32), u64)>;
+    fn is_known(&mut self, h: &Hash256) -> Result<Option<(u32, u32)>>;
+    fn data_get(
+        &mut self,
+        slab: u32,
+        offset: u32,
+        nr_entries: u32,
+        partial: Option<(u32, u32)>,
+    ) -> Result<(Arc<Vec<u8>>, usize, usize)>;
+
+    fn flush(&mut self) -> Result<()>;
+    fn ensure_extra_capacity(&mut self, blocks: usize) -> Result<()>;
+}
+pub enum Backend {
+    File(Box<SlabFile>, Arc<Mutex<SlabFile>>, usize),
+    Redb(PathBuf),
+}
+
+pub fn make_store(cfg: Backend) -> anyhow::Result<Box<dyn Store>> {
+    Ok(match cfg {
+        Backend::File(slab_file, hashes_file, slab_capacity) => {
+            Box::new(Data::new(slab_file, hashes_file, slab_capacity)?)
+        }
+        Backend::Redb(path_buf) => Box::new(DedupStore::new(&path_buf)?),
+    })
+}
+
+pub fn complete_slab_(slab: &mut SlabFile, buf: &mut Vec<u8>) -> Result<()> {
+    slab.write_slab(buf)?;
+    buf.clear();
+    Ok(())
+}
+
+pub fn complete_slab(slab: &mut SlabFile, buf: &mut Vec<u8>, threshold: usize) -> Result<bool> {
+    if buf.len() > threshold {
+        complete_slab_(slab, buf)?;
+        Ok(true)
+    } else {
+        Ok(false)
+    }
+}

--- a/src/archive/file_based.rs
+++ b/src/archive/file_based.rs
@@ -1,14 +1,15 @@
 use anyhow::Result;
+use std::io::Write;
+use std::num::NonZeroUsize;
+use std::sync::{Arc, Mutex};
 
-use crate::cuckoo_filter::*;
+use crate::archive::data::{complete_slab, complete_slab_, Store};
+use crate::cuckoo_filter::{CuckooFilter, InsertResult};
 use crate::hash::*;
 use crate::hash_index::*;
 use crate::iovec::*;
 use crate::paths;
 use crate::slab::*;
-use std::io::Write;
-use std::num::NonZeroUsize;
-use std::sync::{Arc, Mutex};
 
 pub const SLAB_SIZE_TARGET: usize = 4 * 1024 * 1024;
 
@@ -16,7 +17,7 @@ pub struct Data {
     seen: CuckooFilter,
     hashes: lru::LruCache<u32, ByHash>,
 
-    data_file: SlabFile,
+    data_file: Box<SlabFile>,
     hashes_file: Arc<Mutex<SlabFile>>,
 
     current_slab: u32,
@@ -29,24 +30,96 @@ pub struct Data {
     slabs: lru::LruCache<u32, ByIndex>,
 }
 
-fn complete_slab_(slab: &mut SlabFile, buf: &mut Vec<u8>) -> Result<()> {
-    slab.write_slab(buf)?;
-    buf.clear();
-    Ok(())
-}
+impl Store for Data {
+    // Returns the (slab, entry) for the IoVec which may/may not already exist.
+    fn data_add(&mut self, h: Hash256, iov: &IoVec, len: u64) -> Result<((u32, u32), u64)> {
+        // There is an inherent race condition between checking if we have it and adding it,
+        // check before we add when this functionality ends up on a server side.
+        if let Some(location) = self.is_known(&h)? {
+            return Ok((location, 0));
+        }
 
-pub fn complete_slab(slab: &mut SlabFile, buf: &mut Vec<u8>, threshold: usize) -> Result<bool> {
-    if buf.len() > threshold {
-        complete_slab_(slab, buf)?;
-        Ok(true)
-    } else {
-        Ok(false)
+        // Add entry to cuckoo filter, not checking return value as we could get indication that
+        // it's "PossiblyPresent" when our logical expectation is "Inserted".
+        let key = hash_le_u64(&h);
+        self.seen
+            .test_and_set(key, self.current_slab)
+            .or_else(|_| {
+                let new_cap = self.seen.capacity() * 2;
+                self.rebuild_index(new_cap)?;
+                self.seen.test_and_set(key, self.current_slab)
+            })?;
+
+        if self.data_buf.len() as u64 + len > SLAB_SIZE_TARGET as u64 {
+            self.complete_data_slab()?;
+        }
+
+        let r = (self.current_slab, self.current_entries as u32);
+        for v in iov {
+            self.data_buf.extend_from_slice(v);
+        }
+        self.current_entries += 1;
+        self.current_index.insert(h, len as usize);
+        Ok((r, len))
+    }
+
+    // Have we seen this hash before, if we have we will return the slab and offset
+    // Note: This function does not modify any state
+    fn is_known(&mut self, h: &Hash256) -> Result<Option<(u32, u32)>> {
+        let mini_hash = hash_le_u64(h);
+        let rc = match self.seen.test(mini_hash)? {
+            // This is a possibly in set
+            InsertResult::PossiblyPresent(s) => {
+                if self.current_slab == s {
+                    if let Some(offset) = self.current_index.lookup(h) {
+                        Some((self.current_slab, offset))
+                    } else {
+                        None
+                    }
+                } else {
+                    let hi = self.get_hash_index(s)?;
+                    hi.lookup(h).map(|offset| (s, offset as u32))
+                }
+            }
+            _ => None,
+        };
+        Ok(rc)
+    }
+
+    fn data_get(
+        &mut self,
+        slab: u32,
+        offset: u32,
+        nr_entries: u32,
+        partial: Option<(u32, u32)>,
+    ) -> Result<(Arc<Vec<u8>>, usize, usize)> {
+        let info = self.get_info(slab)?;
+        let (data_begin, data_end) = Self::calculate_offsets(offset, nr_entries, info, partial);
+        let data = self.data_file.read(slab)?;
+
+        Ok((data, data_begin, data_end))
+    }
+
+    // Not used at the moment, but was used for the send/receive POC.  This was being called after
+    // we received the newly created stream file for a pack operation.  The reason this is done is
+    // until you complete a slab, you cannot locate it in the data_get path for unpack operation.
+    fn flush(&mut self) -> Result<()> {
+        self.complete_data_slab()
+    }
+
+    fn ensure_extra_capacity(&mut self, blocks: usize) -> Result<()> {
+        if self.seen.capacity() < self.seen.len() + blocks {
+            self.rebuild_index(self.seen.len() + blocks)?;
+            eprintln!("resized index to {}", self.seen.capacity());
+        }
+
+        Ok(())
     }
 }
 
 impl Data {
     pub fn new(
-        data_file: SlabFile,
+        data_file: Box<SlabFile>,
         hashes_file: Arc<Mutex<SlabFile>>,
         slab_capacity: usize,
     ) -> Result<Self> {
@@ -81,15 +154,6 @@ impl Data {
             let hashes = hf.read(slab)?;
             ByIndex::new(hashes)
         })
-    }
-
-    pub fn ensure_extra_capacity(&mut self, blocks: usize) -> Result<()> {
-        if self.seen.capacity() < self.seen.len() + blocks {
-            self.rebuild_index(self.seen.len() + blocks)?;
-            eprintln!("resized index to {}", self.seen.capacity());
-        }
-
-        Ok(())
     }
 
     fn get_hash_index(&mut self, slab: u32) -> Result<&ByHash> {
@@ -151,61 +215,6 @@ impl Data {
             self.current_entries = 0;
         }
         Ok(())
-    }
-
-    // Returns the (slab, entry) for the IoVec which may/may not already exist.
-    pub fn data_add(&mut self, h: Hash256, iov: &IoVec, len: u64) -> Result<((u32, u32), u64)> {
-        // There is an inherent race condition between checking if we have it and adding it,
-        // check before we add when this functionality ends up on a server side.
-        if let Some(location) = self.is_known(&h)? {
-            return Ok((location, 0));
-        }
-
-        // Add entry to cuckoo filter, not checking return value as we could get indication that
-        // it's "PossiblyPresent" when our logical expectation is "Inserted".
-        let key = hash_le_u64(&h);
-        self.seen
-            .test_and_set(key, self.current_slab)
-            .or_else(|_| {
-                let new_cap = self.seen.capacity() * 2;
-                self.rebuild_index(new_cap)?;
-                self.seen.test_and_set(key, self.current_slab)
-            })?;
-
-        if self.data_buf.len() as u64 + len > SLAB_SIZE_TARGET as u64 {
-            self.complete_data_slab()?;
-        }
-
-        let r = (self.current_slab, self.current_entries as u32);
-        for v in iov {
-            self.data_buf.extend_from_slice(v);
-        }
-        self.current_entries += 1;
-        self.current_index.insert(h, len as usize);
-        Ok((r, len))
-    }
-
-    // Have we seen this hash before, if we have we will return the slab and offset
-    // Note: This function does not modify any state
-    pub fn is_known(&mut self, h: &Hash256) -> Result<Option<(u32, u32)>> {
-        let mini_hash = hash_le_u64(h);
-        let rc = match self.seen.test(mini_hash)? {
-            // This is a possibly in set
-            InsertResult::PossiblyPresent(s) => {
-                if self.current_slab == s {
-                    if let Some(offset) = self.current_index.lookup(h) {
-                        Some((self.current_slab, offset))
-                    } else {
-                        None
-                    }
-                } else {
-                    let hi = self.get_hash_index(s)?;
-                    hi.lookup(h).map(|offset| (s, offset as u32))
-                }
-            }
-            _ => None,
-        };
-        Ok(rc)
     }
 
     // NOTE: This won't work for multiple clients and one server!
@@ -273,27 +282,6 @@ impl Data {
         } else {
             (data_begin, data_end)
         }
-    }
-
-    pub fn data_get(
-        &mut self,
-        slab: u32,
-        offset: u32,
-        nr_entries: u32,
-        partial: Option<(u32, u32)>,
-    ) -> Result<(Arc<Vec<u8>>, usize, usize)> {
-        let info = self.get_info(slab)?;
-        let (data_begin, data_end) = Self::calculate_offsets(offset, nr_entries, info, partial);
-        let data = self.data_file.read(slab)?;
-
-        Ok((data, data_begin, data_end))
-    }
-
-    // Not used at the moment, but was used for the send/receive POC.  This was being called after
-    // we received the newly created stream file for a pack operation.  The reason this is done is
-    // until you complete a slab, you cannot locate it in the data_get path for unpack operation.
-    pub fn flush(&mut self) -> Result<()> {
-        self.complete_data_slab()
     }
 
     fn sync_and_close(&mut self) {

--- a/src/archive/mod.rs
+++ b/src/archive/mod.rs
@@ -1,0 +1,3 @@
+pub mod data;
+pub mod file_based;
+pub mod redb_based;

--- a/src/archive/redb_based.rs
+++ b/src/archive/redb_based.rs
@@ -855,7 +855,7 @@ mod test_data_store {
         );
 
         // random read speed
-        if false {
+        if true {
             let random = shuffle_vec(dedup);
             {
                 let mut ad = open_blk_archive(&args)?;

--- a/src/archive/redb_based.rs
+++ b/src/archive/redb_based.rs
@@ -1,0 +1,938 @@
+// redb-backed dedup with database-only metadata, slab files contain only raw chunk data
+// ------------------------------------------------------------------
+// In this design, redb stores all metadata: index, directory, offsets, lengths, hashes, etc.
+// The slab files only contain concatenated raw data chunks (without headers).
+
+use anyhow::{Context, Result};
+use indexmap::IndexMap;
+use redb::ReadableDatabase;
+use redb::{Database, ReadableTable, TableDefinition};
+use std::collections::HashMap;
+use std::fs::{self, File, OpenOptions};
+use std::os::unix::fs::FileExt;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::{error::Error, fmt};
+
+use crate::archive::data::Store;
+use crate::hash::{hash_256, Hash256};
+use crate::iovec::IoVec;
+
+static HASH_TO_INDEX: TableDefinition<&Hash256, &[u8; 12]> = TableDefinition::new("index");
+static SLABMETA: TableDefinition<u64, u64> = TableDefinition::new("slab_meta");
+static META: TableDefinition<&str, u64> = TableDefinition::new("meta");
+static INDEX_TO_OFFSET_LEN_HASH: TableDefinition<(u32, u32), Vec<u8>> =
+    TableDefinition::new("slab_index");
+
+pub struct DedupStore {
+    db: Database,
+    root: PathBuf,
+    slab_id: u32,
+    slab_fd: File,
+    frontier: u64,
+    cursor: u64,
+    max_slab_bytes: u64,
+    staged: IndexMap<Hash256, (u32, u32)>,
+    staged_bytes: u64,
+    flush_threshold_bytes: u64,
+    entries_in_slab: u32,
+    get_index: HashMap<(u32, u32), (u32, u32, Hash256)>,
+}
+
+#[inline]
+fn enc_index(out: &mut [u8; 12], slab: u32, off: u32, len: u32) {
+    out[0..4].copy_from_slice(&slab.to_le_bytes());
+    out[4..8].copy_from_slice(&off.to_le_bytes());
+    out[8..12].copy_from_slice(&len.to_le_bytes());
+}
+
+#[inline]
+fn dec_index(v: &[u8]) -> Option<(u32, u32, u32)> {
+    if v.len() < 12 {
+        return None;
+    }
+    Some((
+        u32::from_le_bytes(v[0..4].try_into().ok()?),
+        u32::from_le_bytes(v[4..8].try_into().ok()?),
+        u32::from_le_bytes(v[8..12].try_into().ok()?),
+    ))
+}
+
+impl Store for DedupStore {
+    fn ensure_extra_capacity(&mut self, _blocks: usize) -> Result<()> {
+        Ok(())
+    }
+
+    fn data_add(&mut self, h: Hash256, iov: &IoVec, len: u64) -> Result<((u32, u32), u64)> {
+        // 0) Return early if we already have this chunk (staged or in the db)
+        if let Some(&(off, l)) = self.staged.get(&h) {
+            return Ok(((self.slab_id, off), l as u64));
+        }
+
+        if let Some(loc) = self.already_indexed(&h)? {
+            return Ok(loc);
+        }
+
+        // 1) Make sure there is room in the current slab (roll if needed)
+        self.ensure_room(len)?;
+
+        // 2) Append raw bytes to the slab and stage metadata (no fsync here)
+        let off_u32 = self.append_to_slab(iov)?;
+        let len_u32 = u32::try_from(len).context("len > u32::MAX not supported")?;
+        self.stage_entry(h, off_u32, len_u32);
+
+        // 3) Auto-publish on threshold; caller can also call publish() explicitly
+        if self.staged_bytes >= self.flush_threshold_bytes {
+            self.publish()?;
+        }
+
+        let ordinal_offset = self.entries_in_slab + self.staged.len() as u32;
+
+        self.get_index
+            .insert((self.slab_id, ordinal_offset - 1), (off_u32, len_u32, h));
+
+        Ok(((self.slab_id, ordinal_offset - 1), len))
+    }
+
+    fn data_get(
+        &mut self,
+        slab: u32,
+        offset: u32,
+        nr_entries: u32,
+        partial: Option<(u32, u32)>,
+    ) -> Result<(Arc<Vec<u8>>, usize, usize)> {
+        if nr_entries == 0 {
+            return Ok((Arc::new(Vec::new()), 0, 0));
+        }
+
+        let rtxn = self.db.begin_read()?;
+        let idx_lookup = rtxn.open_table(INDEX_TO_OFFSET_LEN_HASH)?;
+        let mut offsets = Vec::with_capacity(nr_entries as usize);
+        let mut lengths: Vec<usize> = Vec::with_capacity(nr_entries as usize);
+        let mut hashes = Vec::with_capacity(nr_entries as usize);
+        for ord in offset..offset + nr_entries {
+            // Check the db, else check the in memory
+            let g = idx_lookup.get((slab, ord))?;
+
+            if let Some(g) = g {
+                let block = g.value();
+                let (offset, len, hash) = DedupStore::parse_dir_record(&block)?;
+                offsets.push(offset);
+                lengths.push(len as usize);
+                hashes.push(hash);
+            } else if let Some((offset, len, h)) = self.get_index.get(&(slab, ord)) {
+                offsets.push(*offset);
+                lengths.push(*len as usize);
+                hashes.push(*h)
+            } else {
+                anyhow::bail!(
+                    "data not found {}, {}, {}, {:?}",
+                    slab,
+                    offset,
+                    nr_entries,
+                    partial
+                );
+            }
+        }
+        // Since the file stores raw chunks back-to-back, these entries are contiguous.
+        let region_start = offsets[0] as u64;
+        let region_len: u64 = lengths.iter().map(|&l| l as u64).sum();
+
+        let fd = OpenOptions::new()
+            .read(true)
+            .open(self.root.join(format!("slab-{slab:04}.bin")))?;
+        let mut out = vec![0u8; region_len as usize];
+        fd.read_exact_at(&mut out, region_start)?;
+
+        //Validate that the data is correct by verifying the blake hash is the same as stored
+        validate_data(&out, &lengths, &hashes)?;
+
+        let mut data_begin = 0usize;
+        let mut data_end = region_len as usize;
+
+        // Handle partial
+        (data_begin, data_end) = if let Some((begin, end)) = partial {
+            let data_end = data_begin + end as usize;
+            let data_begin = data_begin + begin as usize;
+            (data_begin, data_end)
+        } else {
+            (data_begin, data_end)
+        };
+
+        Ok((Arc::new(out), data_begin, data_end))
+    }
+
+    fn flush(&mut self) -> Result<()> {
+        self.publish()
+    }
+
+    fn is_known(&mut self, h: &Hash256) -> Result<Option<(u32, u32)>> {
+        if let Some(&(off, _l)) = self.staged.get(h) {
+            return Ok(Some((self.slab_id, off)));
+        }
+
+        if let Some(((slab, offset), _len)) = self.already_indexed(h)? {
+            return Ok(Some((slab, offset)));
+        }
+
+        Ok(None)
+    }
+}
+
+impl DedupStore {
+    // ---------- small helpers to keep data_add clean ----------
+    #[inline]
+    fn already_indexed(&self, h: &Hash256) -> Result<Option<((u32, u32), u64)>> {
+        let rtxn = self.db.begin_read()?;
+        let idx = rtxn.open_table(HASH_TO_INDEX)?;
+        if let Some(g) = idx.get(&h)? {
+            if let Some((slab, off, l)) = dec_index(g.value()) {
+                return Ok(Some(((slab, off), l as u64)));
+            }
+        }
+
+        Ok(None)
+    }
+
+    #[inline]
+    fn ensure_room(&mut self, need: u64) -> Result<()> {
+        if self.cursor + need <= self.max_slab_bytes {
+            return Ok(());
+        }
+        // publish current staged set and roll to a new slab
+        self.publish()?;
+        self.roll_slab()?;
+        Ok(())
+    }
+
+    #[inline]
+    fn append_to_slab(&mut self, iov: &IoVec) -> Result<u32> {
+        let start = self.cursor;
+        let mut off = start;
+
+        for chunk in iov {
+            // write this chunk at the current offset
+            self.slab_fd.write_all_at(chunk, off)?;
+            // advance by chunk length (checked to avoid u64 overflow on pathological input)
+            off = off
+                .checked_add(chunk.len() as u64)
+                .context("offset overflow while appending iov")?;
+        }
+
+        // update the slab cursor to the end of the appended region
+        self.cursor = off;
+
+        // return starting offset as u32 (match original API)
+        u32::try_from(start).context("offset exceeds u32::MAX")
+    }
+
+    #[inline]
+    fn stage_entry(&mut self, h: Hash256, off: u32, len: u32) {
+        self.staged.insert(h, (off, len));
+        self.staged_bytes += len as u64;
+    }
+
+    pub fn new<P: AsRef<Path>>(root: P) -> Result<Self> {
+        DedupStore::open(root)
+    }
+
+    pub fn open<P: AsRef<Path>>(root: P) -> Result<Self> {
+        const ONE_GIB: u64 = 1u64 << 30;
+        const DEFAULT_FLUSH: u64 = 128u64 << 20;
+
+        let frontier: u64;
+        let active_id: u32;
+
+        let root = root.as_ref().to_path_buf();
+        fs::create_dir_all(&root)?;
+        let db = Database::create(root.join("index.redb"))?;
+
+        let write = db.begin_write()?;
+        {
+            let mut meta = write.open_table(META)?;
+            let next = meta.get("next_slab_id")?.map(|g| g.value()).unwrap_or(0);
+            active_id = next.saturating_sub(1) as u32;
+            if next == 0 {
+                meta.insert("next_slab_id", 1)?;
+            }
+            let mut smeta = write.open_table(SLABMETA)?;
+            frontier = smeta.get(active_id as u64)?.map(|g| g.value()).unwrap_or(0);
+            if next == 0 {
+                smeta.insert(active_id as u64, 0)?;
+            }
+            // ensure directory table exists
+            let _ = write.open_table(INDEX_TO_OFFSET_LEN_HASH)?;
+            let _ = write.open_table(HASH_TO_INDEX)?;
+        }
+        write.commit()?;
+
+        let slab_path = root.join(format!("slab-{active_id:04}.bin"));
+        let fd = OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .truncate(false)
+            .open(&slab_path)?;
+        let len = fd.metadata()?.len();
+        if len > frontier {
+            fd.set_len(frontier)?;
+        }
+
+        Ok(Self {
+            db,
+            root,
+            slab_id: active_id,
+            slab_fd: fd,
+            frontier,
+            cursor: frontier,
+            max_slab_bytes: ONE_GIB,
+            staged: IndexMap::new(),
+            staged_bytes: 0,
+            flush_threshold_bytes: DEFAULT_FLUSH,
+            entries_in_slab: 0,
+            get_index: HashMap::new(),
+        })
+    }
+
+    fn current_slab_path(&self) -> PathBuf {
+        self.root.join(format!("slab-{:04}.bin", self.slab_id))
+    }
+
+    #[inline]
+    fn fdatasync(fd: &File) -> Result<()> {
+        fd.sync_data()?;
+        Ok(())
+    }
+
+    fn parse_dir_record(bytes: &[u8]) -> Result<(u32, u32, Hash256)> {
+        if bytes.len() < 4 + 4 + 32 {
+            anyhow::bail!("dir record too short: {} bytes", bytes.len());
+        }
+        let off = u32::from_le_bytes(bytes[0..4].try_into().unwrap());
+        let len = u32::from_le_bytes(bytes[4..8].try_into().unwrap());
+        let mut h: Hash256 = [0u8; 32];
+        h.copy_from_slice(&bytes[8..40]);
+        Ok((off, len, h))
+    }
+
+    pub fn publish(&mut self) -> Result<()> {
+        if self.staged.is_empty() {
+            return Ok(());
+        }
+
+        // 1) Make slab durable up to cursor
+        Self::fdatasync(&self.slab_fd)?;
+
+        // 2) Atomically publish index + frontier
+        let wtxn = self.db.begin_write()?;
+        {
+            let mut idx = wtxn.open_table(HASH_TO_INDEX)?;
+            let mut dir = wtxn.open_table(INDEX_TO_OFFSET_LEN_HASH)?;
+            for (i, (h, (off, len))) in self.staged.iter().enumerate() {
+                if idx.get(&h)?.is_none() {
+                    let mut encoded = [0u8; 12];
+                    enc_index(&mut encoded, self.slab_id, *off, *len);
+                    idx.insert(&h, &encoded)?;
+                }
+                let ord = self.entries_in_slab + i as u32;
+                let mut rec = Vec::with_capacity(4 + 4 + 32);
+                rec.extend_from_slice(&off.to_le_bytes());
+                rec.extend_from_slice(&len.to_le_bytes());
+                rec.extend_from_slice(h);
+                dir.insert((self.slab_id, ord), &rec)?;
+            }
+            wtxn.open_table(SLABMETA)?
+                .insert(self.slab_id as u64, self.cursor)?;
+        }
+        wtxn.commit()?;
+
+        self.frontier = self.cursor;
+        self.entries_in_slab += self.staged.len() as u32;
+        self.staged.clear();
+        self.staged_bytes = 0;
+        self.get_index.clear();
+        Ok(())
+    }
+
+    fn roll_slab(&mut self) -> Result<()> {
+        if !self.staged.is_empty() {
+            self.publish()?;
+        }
+
+        let new_id: u32;
+
+        let w = self.db.begin_write()?;
+        {
+            let mut meta = w.open_table(META)?;
+            let next = meta
+                .get("next_slab_id")?
+                .map(|g| g.value())
+                .unwrap_or(self.slab_id as u64 + 1);
+            new_id = next as u32;
+            meta.insert("next_slab_id", next + 1)?;
+            w.open_table(SLABMETA)?.insert(new_id as u64, 0)?;
+        }
+        w.commit()?;
+
+        self.slab_id = new_id;
+        self.slab_fd = OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .truncate(false)
+            .open(self.current_slab_path())?;
+        self.frontier = 0;
+        self.cursor = 0;
+        self.entries_in_slab = 0;
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ValidateError {
+    /// lengths.len() != expected_hashes.len()
+    CountMismatch { lengths: usize, hashes: usize },
+    /// Sum(lengths) != buf.len()
+    LengthSumMismatch { sum: usize, buf: usize },
+    /// Hash mismatch at chunk index
+    HashMismatch {
+        index: usize,
+        expected: [u8; 32],
+        actual: [u8; 32],
+    },
+}
+
+impl fmt::Display for ValidateError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::CountMismatch { lengths, hashes } => {
+                write!(f, "count mismatch: {lengths} lengths vs {hashes} hashes")
+            }
+            Self::LengthSumMismatch { sum, buf } => {
+                write!(f, "total length mismatch: sum({sum}) != buf({buf})")
+            }
+            Self::HashMismatch { index, .. } => write!(f, "hash mismatch at index {index}"),
+        }
+    }
+}
+impl Error for ValidateError {}
+
+/// Validate that `buf` is the concatenation of `lengths` chunks whose
+/// BLAKE3 hashes match `expected_hashes` (32-byte digests).
+pub fn validate_data(
+    buf: &[u8],
+    lengths: &[usize],
+    expected_hashes: &[[u8; 32]],
+) -> Result<(), ValidateError> {
+    // 1) Same number of lengths and hashes?
+    if lengths.len() != expected_hashes.len() {
+        return Err(ValidateError::CountMismatch {
+            lengths: lengths.len(),
+            hashes: expected_hashes.len(),
+        });
+    }
+
+    // 2) Do the lengths cover the buffer exactly?
+    let mut sum: usize = 0;
+    for &len in lengths {
+        // checked add to guard against overflow on pathological inputs
+        sum = sum.checked_add(len).expect("length sum overflow");
+    }
+    if sum != buf.len() {
+        return Err(ValidateError::LengthSumMismatch {
+            sum,
+            buf: buf.len(),
+        });
+    }
+
+    // 3) Hash each chunk and compare
+    let mut off = 0usize;
+    for (i, (&len, expected)) in lengths.iter().zip(expected_hashes).enumerate() {
+        let end = off + len; // safe: we already checked the total equals buf.len()
+        let chunk = &buf[off..end];
+
+        let actual = hash_256(chunk); // [u8; 32]
+        if &actual != expected {
+            return Err(ValidateError::HashMismatch {
+                index: i,
+                expected: *expected,
+                actual,
+            });
+        }
+
+        off = end;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod test_data_store {
+    use super::*;
+    use crate::hash::hash_256_iov;
+    use crate::iovec::to_iovec;
+    use chrono::prelude::*;
+    use rand::seq::SliceRandom;
+    use size_display::Size;
+    use std::collections::HashSet;
+    use std::fs;
+    use std::io;
+    use std::path::Path;
+    use std::sync::Mutex;
+
+    use crate::archive::data::Store;
+    use crate::archive::file_based::{Data, SLAB_SIZE_TARGET};
+    use crate::create::{archive_create, CreateArgs};
+    use crate::paths::*;
+    use crate::slab::SlabFileBuilder;
+
+    fn dir_size(path: &Path) -> io::Result<u64> {
+        let mut size = 0;
+
+        if path.is_dir() {
+            for entry in fs::read_dir(path)? {
+                let entry = entry?;
+                let metadata = entry.metadata()?;
+
+                if metadata.is_file() {
+                    size += metadata.len();
+                } else if metadata.is_dir() {
+                    size += dir_size(&entry.path())?;
+                }
+            }
+        } else if path.is_file() {
+            size += fs::metadata(path)?.len();
+        }
+
+        Ok(size)
+    }
+
+    fn dedup_keep_order(vec: Vec<((u32, u32), u64)>) -> Vec<((u32, u32), u64)> {
+        let mut seen = HashSet::new();
+        let mut result = Vec::new();
+
+        for item in vec {
+            if seen.insert(item.clone()) {
+                result.push(item);
+            }
+        }
+
+        result
+    }
+
+    fn shuffle_vec(mut vec: Vec<((u32, u32), u64)>) -> Vec<((u32, u32), u64)> {
+        let mut rng = rand::thread_rng();
+        vec.shuffle(&mut rng);
+        vec
+    }
+
+    #[test]
+    fn roundtrip_meta_in_db() -> Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let mut store = DedupStore::open(tmp.path())?;
+        store.flush_threshold_bytes = 32 * 1024;
+
+        for idx in 0..2 {
+            let mut data: Vec<u8> = vec![1u8; 4096];
+            fastrand::Rng::new().fill(&mut data);
+            let iov = to_iovec(&data);
+            let h = hash_256_iov(&iov);
+
+            let ((slab, returned_off), len) = store.data_add(h, &iov, iov.len() as u64)?;
+            assert_eq!(slab, 0);
+            assert_eq!(idx, returned_off);
+            assert_eq!(data.len(), len as usize);
+            store.publish()?;
+
+            let (arc, start, end) = store.data_get(slab, idx, 1, None)?;
+            assert_eq!(&arc[start..end], &data[..]);
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn more_than_one_entry() -> Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let mut store = DedupStore::open(tmp.path())?;
+
+        let mut buf = vec![0u8; 64 * 1024];
+        fastrand::Rng::new().fill(&mut buf);
+
+        let mid = 32 * 1024 as usize;
+        let first_half = &buf[0..mid];
+        let second_half = &buf[mid..];
+
+        let f_iov = to_iovec(&first_half);
+        let h = hash_256_iov(&f_iov);
+        let ((slab, off), len) = store.data_add(h, &f_iov, f_iov.len() as u64)?;
+        eprintln!("data_add {slab}, {off}, {len}");
+
+        let s_iov = to_iovec(&second_half);
+        let h = hash_256_iov(&s_iov);
+
+        let ((slab2, off2), len2) = store.data_add(h, &s_iov, s_iov.len() as u64)?;
+        eprintln!("data_add {slab2}, {off2}, {len2}");
+
+        // Check before and after publish, to ensure we are handling entries in flight that haven't made it
+        // to the db, and then after everything has been flushed to persistent storage.
+        let (arc, start, end) = store.data_get(slab, off, 2, None)?;
+        assert_eq!(&arc[start..end], &buf[..]);
+
+        store.publish()?;
+
+        let (arc, start, end) = store.data_get(slab, off, 2, None)?;
+        assert_eq!(&arc[start..end], &buf[..]);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_partial_db() -> Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let mut store = DedupStore::open(tmp.path())?;
+        store.flush_threshold_bytes = 32 * 1024;
+
+        let mut buf = vec![0u8; 64 * 1024];
+        fastrand::Rng::new().fill(&mut buf);
+
+        let mid = 32 * 1024 as usize;
+        let first_half = &buf[0..mid];
+        let second_half = &buf[mid..];
+
+        let f_iov = to_iovec(&first_half);
+
+        let h = hash_256_iov(&f_iov);
+        let ((slab, off), len) = store.data_add(h, &f_iov, f_iov.len() as u64)?;
+        eprintln!("data_add {slab}, {off}, {len}");
+
+        let s_iov = to_iovec(&second_half);
+        let h = hash_256_iov(&s_iov);
+
+        let ((_slab2, _off2), _len2) = store.data_add(h, &s_iov, s_iov.len() as u64)?;
+        eprintln!("data_add {slab}, {off}, {len}");
+
+        // Check before and after publish, to ensure we are handling entries in flight that haven't made it
+        // to the db, and then after everything has been flushed to persistent storage.
+        let (arc, start, end) = store.data_get(slab, off, 2, Some((10, 20)))?;
+        assert_eq!(&arc[start..end], &buf[10..20]);
+
+        store.publish()?;
+
+        let (arc, start, end) = store.data_get(slab, off, 2, Some((10, 20)))?;
+        assert_eq!(&arc[start..end], &buf[10..20]);
+
+        Ok(())
+    }
+
+    #[test]
+    fn roundtrip_and_group_commit() -> Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let mut store = DedupStore::open(tmp.path())?;
+        // make it easy to trigger auto-publish quickly
+        store.flush_threshold_bytes = 32 * 1024; // 32 KiB
+
+        // add a block and confirm it dedups on second add without publishing
+        let data = vec![7u8; 20 * 1024];
+        let len = data.len();
+
+        let iov = to_iovec(&data);
+        let h = hash_256_iov(&iov);
+        let ((slab, off), _len) = store.data_add(h, &iov, len as u64)?;
+        let ((slab2, off2), _len2) = store.data_add(h, &iov, len as u64)?;
+
+        assert_eq!((slab, off), (slab2, off2));
+
+        // force publish and read back
+        store.publish()?;
+        let (arc, _, _) = store.data_get(slab, off, 1, None)?;
+        assert_eq!(&arc[..], &data[..]);
+        Ok(())
+    }
+
+    #[test]
+    fn rollover_at_boundary() -> Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let mut store = DedupStore::open(tmp.path())?;
+        // tiny limit to trigger roll quickly in test
+        store.max_slab_bytes = 64 * 1024; // 64 KiB
+        store.flush_threshold_bytes = u64::MAX; // manual publish only
+
+        let chunk = vec![0u8; 16 * 1024];
+
+        let iov = to_iovec(&chunk);
+        let h = hash_256_iov(&iov);
+
+        let ((slab0, _), _) = store.data_add(h, &iov, iov.len() as u64)?;
+        // write more to exceed slab size, should auto-publish+roll
+        for i in 0..4 {
+            let chunk = vec![i as u8; 16 * 1024];
+            let iov = to_iovec(&chunk);
+            let h = hash_256_iov(&iov);
+
+            let _ = store.data_add(h, &iov, iov.len() as u64)?;
+        }
+        // ensure a publish happens so frontier == cursor and then roll
+        store.publish()?;
+
+        let chunk = vec![5 as u8; 16 * 1024];
+        let iov = to_iovec(&chunk);
+        let h = hash_256_iov(&iov);
+        let ((slab1, _), _) = store.data_add(h, &iov, iov.len() as u64)?;
+        assert!(slab1 >= slab0);
+        Ok(())
+    }
+
+    const NUM_WRITES: usize = 89292;
+
+    #[test]
+    fn database_backend_speed() -> Result<()> {
+        let tmp = tempfile::tempdir()?;
+
+        let mut buf = vec![0u8; 32 * 1024];
+
+        let total_read = NUM_WRITES * buf.len();
+        let mut inserts: Vec<((u32, u32), u64)> = Vec::new();
+
+        let mut start: DateTime<Utc> = Utc::now();
+        {
+            let mut store = DedupStore::open(tmp.path())?;
+            for _ in 0..NUM_WRITES {
+                fastrand::Rng::new().fill(&mut buf);
+                let iov = to_iovec(&buf);
+                let h = hash_256_iov(&iov);
+                inserts.push(store.data_add(h, &iov, iov.len() as u64)?);
+            }
+            store.publish()?;
+        }
+        let mut end: DateTime<Utc> = Utc::now();
+        let elapsed = end - start;
+        let elapsed = elapsed.num_milliseconds() as f64 / 1000.0;
+        eprintln!(
+            "database backend speed: {:.2}/s",
+            Size((total_read as f64 / elapsed) as u64)
+        );
+        let total_bytes = dir_size(tmp.path())?;
+        eprintln!("total bytes on disk = {total_bytes}");
+
+        let total_inserts = inserts.len();
+
+        // Lets test read speed
+        let dedup = dedup_keep_order(inserts);
+
+        eprintln!("The number of dups found = {}", total_inserts - dedup.len());
+        {
+            let mut store = DedupStore::open(tmp.path())?;
+            start = Utc::now();
+            for ((slab_id, slab_offset), _len) in &dedup {
+                let (_buffer, _start, _len) = store.data_get(*slab_id, *slab_offset, 1, None)?;
+            }
+        }
+        end = Utc::now();
+
+        let elapsed = end - start;
+        let elapsed_seconds = elapsed.num_milliseconds() as f64 / 1000.0;
+        eprintln!(
+            "database backend read speed sequential: {:.2}/s",
+            Size((total_read as f64 / elapsed_seconds) as u64)
+        );
+
+        let random = shuffle_vec(dedup);
+        {
+            let mut store = DedupStore::open(tmp.path())?;
+            start = Utc::now();
+            for ((slab_id, slab_offset), _len) in random {
+                let (_buffer, _start, _len) = store.data_get(slab_id, slab_offset, 1, None)?;
+            }
+            end = Utc::now();
+        }
+
+        let elapsed = end - start;
+        let elapsed_seconds = elapsed.num_milliseconds() as f64 / 1000.0;
+        eprintln!(
+            "database backend read speed random: {:.2}/s",
+            Size((total_read as f64 / elapsed_seconds) as u64)
+        );
+
+        Ok(())
+    }
+
+    fn open_blk_archive(args: &CreateArgs) -> Result<Data> {
+        let data_file = SlabFileBuilder::open(data_path())
+            .write(true)
+            .queue_depth(128)
+            .build()
+            .context("couldn't open data slab file")?;
+
+        let hashes_inner = SlabFileBuilder::open(hashes_path())
+            .write(true)
+            .queue_depth(128)
+            .build()
+            .context("couldn't open hashes file")?;
+
+        let hashes_file = Arc::new(Mutex::new(hashes_inner));
+
+        let hashes_per_slab = std::cmp::max(SLAB_SIZE_TARGET / args.block_size, 1);
+        let slab_capacity = ((args.hash_cache_size_meg * 1024 * 1024)
+            / std::mem::size_of::<Hash256>())
+            / hashes_per_slab;
+
+        Data::new(Box::new(data_file), hashes_file, slab_capacity)
+    }
+
+    #[test]
+    fn zblk_archive_backend_speed() -> Result<()> {
+        let tmp = tempfile::tempdir()?;
+
+        let mut start: DateTime<Utc>;
+
+        let path_ref = tmp.path();
+        let path_buf: PathBuf = path_ref.to_path_buf();
+
+        let args = CreateArgs {
+            dir: path_buf,
+            data_compression: false,
+            block_size: 4096,
+            hash_cache_size_meg: 1024,
+            data_cache_size_meg: 1024,
+        };
+
+        archive_create(&args)?;
+
+        let mut buf = vec![0u8; 32 * 1024];
+
+        let mut inserts: Vec<((u32, u32), u64)> = Vec::new();
+
+        {
+            let mut ad = open_blk_archive(&args)?;
+            start = Utc::now();
+            for _ in 0..NUM_WRITES {
+                fastrand::Rng::new().fill(&mut buf);
+                {
+                    let mut iv = IoVec::new();
+                    iv.push(&buf[..]);
+                    let h = hash_256_iov(&iv);
+                    inserts.push(ad.data_add(h, &iv, buf.len() as u64)?);
+                }
+            }
+        }
+
+        let total_read = NUM_WRITES * buf.len();
+        let mut end: DateTime<Utc> = Utc::now();
+        let elapsed = end - start;
+        let elapsed_seconds = elapsed.num_milliseconds() as f64 / 1000.0;
+        eprintln!(
+            "blk-archive backend write speed: {:.2}/s",
+            Size((total_read as f64 / elapsed_seconds) as u64)
+        );
+        let total_bytes = dir_size(tmp.path())?;
+        eprintln!("total bytes on disk = {total_bytes}");
+
+        // Lets test read speed
+        let total_inserts = inserts.len();
+        let dedup = dedup_keep_order(inserts);
+        eprintln!("The number of dups found = {}", total_inserts - dedup.len());
+
+        /*
+        for d in &dedup {
+            eprintln!("{:?}", d);
+        }
+        */
+
+        {
+            let mut ad = open_blk_archive(&args)?;
+            start = Utc::now();
+            for ((slab_id, slab_offset), _len) in &dedup {
+                let (_buffer, _start, _len) = ad.data_get(*slab_id, *slab_offset, 1, None)?;
+            }
+        }
+        end = Utc::now();
+
+        let elapsed = end - start;
+        let elapsed_seconds = elapsed.num_milliseconds() as f64 / 1000.0;
+        eprintln!(
+            "blk-archive backend read speed sequential: {:.2}/s",
+            Size((total_read as f64 / elapsed_seconds) as u64)
+        );
+
+        // random read speed
+        if false {
+            let random = shuffle_vec(dedup);
+            {
+                let mut ad = open_blk_archive(&args)?;
+                start = Utc::now();
+                for ((slab_id, slab_offset), _len) in random {
+                    let (_buffer, _start, _len) = ad.data_get(slab_id, slab_offset, 1, None)?;
+                }
+            }
+            end = Utc::now();
+
+            let elapsed = end - start;
+            let elapsed_seconds = elapsed.num_milliseconds() as f64 / 1000.0;
+            eprintln!(
+                "blk-archive backend read speed random: {:.2}/s",
+                Size((total_read as f64 / elapsed_seconds) as u64)
+            );
+        } else {
+            eprintln!("skipping random read test...");
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_partial_existing() -> Result<()> {
+        let tmp = tempfile::tempdir()?;
+
+        let path_ref = tmp.path();
+        let path_buf: PathBuf = path_ref.to_path_buf();
+
+        let args = CreateArgs {
+            dir: path_buf,
+            data_compression: false,
+            block_size: 4096,
+            hash_cache_size_meg: 1024,
+            data_cache_size_meg: 1024,
+        };
+
+        archive_create(&args)?;
+
+        let mut buf = vec![0u8; 64 * 1024];
+        fastrand::Rng::new().fill(&mut buf);
+
+        let mid = 32 * 1024 as usize;
+        let first_half = &buf[0..mid];
+        let second_half = &buf[mid..];
+        let returned_data: (Arc<Vec<u8>>, usize, usize);
+
+        {
+            let mut ad = open_blk_archive(&args)?;
+
+            let mut iv = IoVec::new();
+            iv.push(&first_half);
+            let h = hash_256_iov(&iv);
+            let ((slab, off), len) = ad.data_add(h, &iv, first_half.len() as u64)?;
+            eprintln!("data_add 1 {slab}, {off}, {len}");
+
+            let mut iv = IoVec::new();
+            iv.push(&second_half);
+            let h = hash_256_iov(&iv);
+
+            let ((slab2, off2), len2) = ad.data_add(h, &iv, second_half.len() as u64)?;
+            eprintln!("data_add 2 {slab2}, {off2}, {len2}");
+
+            ad.flush()?;
+
+            // We have a race condition in droping the backend and having the write treads finish.
+            std::thread::sleep(std::time::Duration::from_millis(5000));
+
+            returned_data = ad.data_get(slab, off, 2, Some((10, 20)))?;
+        }
+
+        let (arc, start, end) = (returned_data.0, returned_data.1, returned_data.2);
+
+        assert_eq!(&arc[start..end], &buf[10..20]);
+        Ok(())
+    }
+}
+
+pub fn main() {}

--- a/src/config.rs
+++ b/src/config.rs
@@ -54,6 +54,7 @@ pub struct StreamConfig {
     pub mapped_size: u64,
     pub packed_size: u64,
     pub thin_id: Option<u32>,
+    pub source_sig: Option<String>,
 }
 
 pub fn read_stream_config(stream_id: &str) -> Result<StreamConfig> {
@@ -104,6 +105,7 @@ mod config_tests {
             mapped_size: u64::MAX,
             packed_size: u64::MAX,
             thin_id: None,
+            source_sig: None,
         };
 
         let ser = serde_yaml_ng::to_string(&config).unwrap();

--- a/src/config.rs
+++ b/src/config.rs
@@ -84,8 +84,8 @@ pub fn now() -> String {
     dt.to_rfc3339()
 }
 
-pub fn to_date_time(t: &str) -> chrono::DateTime<FixedOffset> {
-    DateTime::parse_from_rfc3339(t).unwrap()
+pub fn to_date_time(t: &str) -> Result<chrono::DateTime<FixedOffset>> {
+    DateTime::parse_from_rfc3339(t).with_context(|| format!("Failed to parse datetime: {}", t))
 }
 
 //-----------------------------------------

--- a/src/content_sensitive_splitter.rs
+++ b/src/content_sensitive_splitter.rs
@@ -53,7 +53,7 @@ impl ContentSensitiveSplitter {
         self.consume_c.block -= first_used;
     }
 
-    fn consume(&mut self, len: usize) -> IoVec {
+    fn consume(&mut self, len: usize) -> IoVec<'_> {
         let c = &mut self.consume_c;
         let blocks = &self.blocks;
 
@@ -88,7 +88,7 @@ impl ContentSensitiveSplitter {
         r
     }
 
-    fn consume_all(&mut self) -> IoVec {
+    fn consume_all(&mut self) -> IoVec<'_> {
         let c = &mut self.consume_c;
         let mut r = IoVec::new();
         while c.block < self.blocks.len() {

--- a/src/content_sensitive_splitter.rs
+++ b/src/content_sensitive_splitter.rs
@@ -382,6 +382,21 @@ mod splitter_tests {
         assert_eq!(input_buf, output_buf);
     }
 
+    fn open_out(name: &str) -> std::io::Result<std::fs::File> {
+        use std::{
+            fs::{self, OpenOptions},
+            path::PathBuf,
+        };
+        let mut dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")); // absolute path to crate root
+        dir.push("target"); // or "results", etc.
+        fs::create_dir_all(&dir)?;
+        OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .open(dir.join(name))
+    }
+
     #[test]
     fn splitter_finds_similar_blocks() {
         let input_buf = prep_data();
@@ -397,7 +412,7 @@ mod splitter_tests {
         }
 
         let lengths = handler.lengths();
-        let mut csv = std::fs::File::create("dedup-lengths.csv").unwrap();
+        let mut csv = open_out("dedup-lengths.csv").unwrap();
         for (len, hits) in lengths {
             writeln!(csv, "{}, {}", len, hits).expect("write failed");
         }

--- a/src/hash_index.rs
+++ b/src/hash_index.rs
@@ -96,7 +96,12 @@ fn pos(index: usize) -> usize {
 }
 
 fn get_hash(data: &[u8], i: usize) -> &Hash256 {
-    Hash256::from_slice(&data[pos(i)..pos(i + 1)])
+    let start = pos(i);
+    let end = pos(i + 1);
+    data[start..end]
+        .try_into()
+        .map(|arr: &Hash256| arr)
+        .expect("slice not 32 bytes")
 }
 
 fn bsearch(h: &Hash256, data: &[u8], max: usize) -> Option<usize> {

--- a/src/iovec.rs
+++ b/src/iovec.rs
@@ -2,11 +2,49 @@ use anyhow::Result;
 
 //-----------------------------------------
 
-pub type IoVec<'a> = Vec<&'a [u8]>;
+pub struct IoVec<'a>(pub Vec<&'a [u8]>);
 
 pub trait IoVecHandler {
     fn handle_data(&mut self, iov: &IoVec) -> Result<()>;
     fn complete(&mut self) -> Result<()>;
 }
 
-//-----------------------------------------
+/// Allow `IoVec::from(slice)`
+impl<'a> From<&'a [u8]> for IoVec<'a> {
+    fn from(s: &'a [u8]) -> Self {
+        IoVec(vec![s])
+    }
+}
+
+pub fn to_iovec(buf: &[u8]) -> IoVec<'_> {
+    IoVec::from(buf)
+}
+
+impl<'a> IoVec<'a> {
+    pub fn new() -> Self {
+        IoVec(Vec::new())
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.iter().map(|s| s.len()).sum()
+    }
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    pub fn iter(&self) -> std::slice::Iter<'_, &'a [u8]> {
+        self.0.iter()
+    }
+
+    pub fn push(&mut self, slice: &'a [u8]) {
+        self.0.push(slice);
+    }
+}
+
+impl<'a, 'b> IntoIterator for &'b IoVec<'a> {
+    type Item = &'b &'a [u8];
+    type IntoIter = std::slice::Iter<'b, &'a [u8]>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter()
+    }
+}

--- a/src/iovec.rs
+++ b/src/iovec.rs
@@ -16,6 +16,12 @@ impl<'a> From<&'a [u8]> for IoVec<'a> {
     }
 }
 
+impl<'a> Default for IoVec<'a> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 pub fn to_iovec(buf: &[u8]) -> IoVec<'_> {
     IoVec::from(buf)
 }

--- a/src/list.rs
+++ b/src/list.rs
@@ -31,7 +31,7 @@ pub fn run(matches: &ArgMatches, output: Arc<Output>) -> Result<()> {
     let mut streams = Vec::new();
     for id in stream_ids {
         let cfg = config::read_stream_config(&id)?;
-        streams.push((id, config::to_date_time(&cfg.pack_time), cfg));
+        streams.push((id, config::to_date_time(&cfg.pack_time)?, cfg));
     }
 
     streams.sort_by(|l, r| l.1.cmp(&r.1));

--- a/src/slab/compression_service.rs
+++ b/src/slab/compression_service.rs
@@ -115,7 +115,7 @@ fn compression_worker_<C: Compressor>(
             let compressed_data = match compressor.compress(&data.data) {
                 Ok(data) => data,
                 Err(e) => {
-                    let _ = error_tx.send(e.into());
+                    let _ = error_tx.send(e);
                     continue;
                 }
             };

--- a/src/thin_metadata.rs
+++ b/src/thin_metadata.rs
@@ -354,7 +354,9 @@ fn find_device(major: u32, minor: u32) -> Option<PathBuf> {
 
     for device in enumerator.scan_devices().unwrap() {
         if let Some(devnum) = device.devnum() {
+            #[allow(unused_unsafe)]
             let found_major = unsafe { libc::major(devnum) };
+            #[allow(unused_unsafe)]
             let found_minor = unsafe { libc::minor(devnum) };
 
             if found_major == major && found_minor == minor {

--- a/src/unpack.rs
+++ b/src/unpack.rs
@@ -749,7 +749,7 @@ pub fn run_verify(matches: &ArgMatches, output: Arc<Output>) -> Result<()> {
     let stored_hash = stream_cfg.source_sig;
 
     let calculated_hash = if matches.get_flag("internal") {
-        run_verify_stream(&stream, output, stream_cfg.size, cache_nr_entries)?
+        run_verify_stream(stream, output, stream_cfg.size, cache_nr_entries)?
     } else {
         run_verify_device_or_file(
             input_file,

--- a/src/unpack.rs
+++ b/src/unpack.rs
@@ -10,7 +10,7 @@ use std::fs;
 use std::fs::{File, OpenOptions};
 use std::io;
 use std::os::unix::io::AsRawFd;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 use crate::archive;
@@ -25,6 +25,7 @@ use crate::slab::*;
 use crate::stream;
 use crate::stream::*;
 use crate::thin_metadata::*;
+use crate::utils::unmapped_digest_add;
 
 //-----------------------------------------
 
@@ -32,7 +33,7 @@ use crate::thin_metadata::*;
 trait UnpackDest {
     fn handle_mapped(&mut self, data: &[u8]) -> Result<()>;
     fn handle_unmapped(&mut self, len: u64) -> Result<()>;
-    fn complete(&mut self) -> Result<()>;
+    fn complete(&mut self) -> Result<String>;
 }
 
 struct Unpacker<D: UnpackDest> {
@@ -106,7 +107,7 @@ impl<D: UnpackDest> Unpacker<D> {
         Ok(())
     }
 
-    fn unpack(&mut self, output: Arc<Output>, total: u64) -> Result<()> {
+    fn unpack(&mut self, output: Arc<Output>, total: u64) -> Result<String> {
         output.report.progress(0);
 
         let nr_slabs = self.stream_file.get_nr_slabs();
@@ -133,7 +134,7 @@ impl<D: UnpackDest> Unpacker<D> {
             }
         }
 
-        self.dest.complete()?;
+        let result = self.dest.complete()?;
         output.report.progress(100);
         let end_time: DateTime<Utc> = Utc::now();
         let elapsed = end_time - start_time;
@@ -149,7 +150,7 @@ impl<D: UnpackDest> Unpacker<D> {
             ));
         }
 
-        Ok(())
+        Ok(result)
     }
 }
 
@@ -157,15 +158,18 @@ impl<D: UnpackDest> Unpacker<D> {
 
 struct ThickDest<W: Write> {
     output: W,
+    digest: blake3::Hasher,
 }
 
-fn write_bytes<W: Write>(w: &mut W, byte: u8, len: u64) -> Result<()> {
+fn write_bytes<W: Write>(w: &mut W, byte: u8, len: u64, digest: &mut blake3::Hasher) -> Result<()> {
     let buf_size = std::cmp::min(len, 64 * 1024 * 1024);
     let buf = vec![byte; buf_size as usize];
 
     let mut remaining = len;
     while remaining > 0 {
         let w_len = std::cmp::min(buf_size, remaining);
+
+        digest.update(&buf[0..(w_len as usize)]);
         w.write_all(&buf[0..(w_len as usize)])?;
         remaining -= w_len;
     }
@@ -175,16 +179,51 @@ fn write_bytes<W: Write>(w: &mut W, byte: u8, len: u64) -> Result<()> {
 
 impl<W: Write> UnpackDest for ThickDest<W> {
     fn handle_mapped(&mut self, data: &[u8]) -> Result<()> {
+        self.digest.update(data);
         self.output.write_all(data)?;
         Ok(())
     }
 
     fn handle_unmapped(&mut self, len: u64) -> Result<()> {
-        write_bytes(&mut self.output, 0, len)
+        write_bytes(&mut self.output, 0, len, &mut self.digest)
     }
 
-    fn complete(&mut self) -> Result<()> {
+    fn complete(&mut self) -> Result<String> {
+        Ok(self.digest.finalize().to_hex().to_string())
+    }
+}
+
+#[derive(Default)]
+struct ValidateStream {
+    digest: blake3::Hasher,
+}
+
+impl ValidateStream {
+    fn digest_bytes(&mut self, byte: u8, len: u64) {
+        let buf_size = std::cmp::min(len, 64 * 1024 * 1024);
+        let buf = vec![byte; buf_size as usize];
+        let mut remaining = len;
+        while remaining > 0 {
+            let w_len = std::cmp::min(buf_size, remaining);
+            self.digest.update(&buf[0..(w_len as usize)]);
+            remaining -= w_len;
+        }
+    }
+}
+
+impl UnpackDest for ValidateStream {
+    fn handle_mapped(&mut self, data: &[u8]) -> Result<()> {
+        self.digest.update(data);
         Ok(())
+    }
+
+    fn handle_unmapped(&mut self, len: u64) -> Result<()> {
+        self.digest_bytes(0, len);
+        Ok(())
+    }
+
+    fn complete(&mut self) -> Result<String> {
+        Ok(self.digest.finalize().to_hex().to_string())
     }
 }
 
@@ -208,6 +247,7 @@ struct ThinDest {
     // (provisioned, len bytes)
     run: Option<(bool, u64)>,
     writes_avoided: u64,
+    digest: blake3::Hasher,
 }
 
 impl ThinDest {
@@ -320,6 +360,9 @@ impl UnpackDest for ThinDest {
         while remaining > 0 {
             let (provisioned, c_len) = self.next_run(remaining)?;
 
+            self.digest
+                .update(&data[offset as usize..(offset + c_len) as usize]);
+
             if provisioned {
                 self.handle_mapped_provisioned(&data[offset as usize..(offset + c_len) as usize])?;
             } else {
@@ -340,6 +383,8 @@ impl UnpackDest for ThinDest {
         while remaining > 0 {
             let (provisioned, c_len) = self.next_run(remaining)?;
 
+            unmapped_digest_add(&mut self.digest, c_len);
+
             if provisioned {
                 self.handle_unmapped_provisioned(c_len)?;
             } else {
@@ -352,10 +397,10 @@ impl UnpackDest for ThinDest {
         Ok(())
     }
 
-    fn complete(&mut self) -> Result<()> {
+    fn complete(&mut self) -> Result<String> {
         assert!(self.run.is_none());
         assert!(self.provisioned.next().is_none());
-        Ok(())
+        Ok(self.digest.finalize().to_hex().to_string())
     }
 }
 
@@ -389,13 +434,16 @@ pub fn run_unpack(matches: &ArgMatches, report_output: Arc<Output>) -> Result<()
     report_output
         .report
         .set_title(&format!("Unpacking {} ...", output_file.display()));
-    if create {
+    let result = if create {
         let config = config::read_config(".", matches)?;
         let cache_nr_entries = (1024 * 1024 * config.data_cache_size_meg) / SLAB_SIZE_TARGET;
 
-        let dest = ThickDest { output };
+        let dest = ThickDest {
+            output,
+            digest: blake3::Hasher::new(),
+        };
         let mut u = Unpacker::new(stream, cache_nr_entries, dest)?;
-        u.unpack(report_output, stream_cfg.size)
+        u.unpack(report_output, stream_cfg.size)?
     } else {
         // Check the size matches the stream size.
         let stream_size = stream_cfg.size;
@@ -422,15 +470,38 @@ pub fn run_unpack(matches: &ArgMatches, report_output: Arc<Output>) -> Result<()
                 provisioned,
                 run: None,
                 writes_avoided: 0,
+                digest: blake3::Hasher::new(),
             };
             let mut u = Unpacker::new(stream, cache_nr_entries, dest)?;
-            u.unpack(report_output, stream_size)
+            u.unpack(report_output, stream_size)?
         } else {
-            let dest = ThickDest { output };
+            let dest = ThickDest {
+                output,
+                digest: blake3::Hasher::new(),
+            };
             let mut u = Unpacker::new(stream, cache_nr_entries, dest)?;
-            u.unpack(report_output, stream_size)
+            u.unpack(report_output, stream_size)?
         }
-    }
+    };
+    compare_hashes(stream_cfg.source_sig, result)?;
+    Ok(())
+}
+
+fn run_verify_stream(
+    stream_id: &str,
+    report_output: Arc<Output>,
+    ouput_size: u64,
+    cache_nr_entries: usize,
+) -> Result<String> {
+    report_output.report.set_title(&format!(
+        "Validating {stream_id} with stored blake3 hash ..."
+    ));
+
+    let dest = ValidateStream {
+        digest: blake3::Hasher::new(),
+    };
+    let mut u = Unpacker::new(stream_id, cache_nr_entries, dest)?;
+    u.unpack(report_output, ouput_size)
 }
 
 //-----------------------------------------
@@ -440,6 +511,7 @@ struct VerifyDest {
     chunk: Option<Chunk>,
     chunk_offset: u64,
     total_verified: u64,
+    digest: blake3::Hasher,
 }
 
 impl VerifyDest {
@@ -449,6 +521,7 @@ impl VerifyDest {
             chunk: None,
             chunk_offset: 0,
             total_verified: 0,
+            digest: blake3::Hasher::new(),
         }
     }
 }
@@ -542,17 +615,35 @@ impl VerifyDest {
 impl UnpackDest for VerifyDest {
     fn handle_mapped(&mut self, expected: &[u8]) -> Result<()> {
         let mut remaining = expected.len() as u64;
-        let mut offset = 0;
+        let mut offset: u64 = 0;
+
         while remaining > 0 {
-            let actual = self.peek_data(remaining)?;
-            let actual_len = actual.len() as u64;
-            if actual != &expected[offset as usize..(offset + actual_len) as usize] {
+            // Borrow from `self` in limited scope
+            let (actual_len, equal) = {
+                let actual = self.peek_data(remaining)?;
+                let actual_len = actual.len() as u64;
+
+                let start = offset as usize;
+                let end = start + actual_len as usize;
+                let expected_slice = &expected[start..end];
+
+                (actual_len, actual == expected_slice)
+            }; // borrow ends here
+
+            if !equal {
                 return Err(self.fail("data mismatch"));
             }
+
+            // Safe to mutably borrow `self` now to update the digest
+            let start = offset as usize;
+            let end = start + actual_len as usize;
+            self.digest.update(&expected[start..end]);
+
             self.consume_data(actual_len)?;
             remaining -= actual_len;
             offset += actual_len;
         }
+
         self.total_verified += expected.len() as u64;
         Ok(())
     }
@@ -563,15 +654,19 @@ impl UnpackDest for VerifyDest {
             let len = self.get_unmapped(remaining)?;
             remaining -= len;
         }
+
+        unmapped_digest_add(&mut self.digest, len);
+
         self.total_verified += len;
         Ok(())
     }
 
-    fn complete(&mut self) -> Result<()> {
+    fn complete(&mut self) -> Result<String> {
         if self.chunk.is_some() || self.input_it.next().is_some() {
             return Err(anyhow!("archived stream is too short"));
         }
-        Ok(())
+
+        Ok(self.digest.finalize().to_hex().to_string())
     }
 }
 
@@ -603,22 +698,17 @@ fn thin_verifier(input_file: &Path) -> Result<VerifyDest> {
     Ok(VerifyDest::new(input_it))
 }
 
-pub fn run_verify(matches: &ArgMatches, output: Arc<Output>) -> Result<()> {
-    let archive_dir = Path::new(matches.get_one::<String>("ARCHIVE").unwrap()).canonicalize()?;
-    let input_file = Path::new(matches.get_one::<String>("INPUT").unwrap()).canonicalize()?;
-    let stream = matches.get_one::<String>("STREAM").unwrap();
-
-    env::set_current_dir(archive_dir)?;
-
-    let config = config::read_config(".", matches)?;
-    let cache_nr_entries = (1024 * 1024 * config.data_cache_size_meg) / SLAB_SIZE_TARGET;
-
-    let stream_cfg = config::read_stream_config(stream)?;
-
+fn run_verify_device_or_file(
+    input_file: PathBuf,
+    output: Arc<Output>,
+    stream_id: &str,
+    cache_nr_entries: usize,
+    size: u64,
+) -> Result<String> {
     output.report.set_title(&format!(
         "Verifying {} and {} match ...",
         input_file.display(),
-        &stream
+        &stream_id
     ));
 
     let dest = if is_thin_device(&input_file)? {
@@ -627,8 +717,51 @@ pub fn run_verify(matches: &ArgMatches, output: Arc<Output>) -> Result<()> {
         thick_verifier(&input_file)?
     };
 
-    let mut u = Unpacker::new(stream, cache_nr_entries, dest)?;
-    u.unpack(output, stream_cfg.size)
+    let mut u = Unpacker::new(stream_id, cache_nr_entries, dest)?;
+    u.unpack(output, size)
+}
+
+fn compare_hashes(stored: Option<String>, calculated_digest: String) -> Result<()> {
+    if let Some(stored) = stored {
+        eprintln!("DEBUG: \tcomparing \n stor {stored} to \n calc {calculated_digest}");
+        if stored != calculated_digest {
+            return Err(anyhow!(
+                    "Hash signatures do not match \n{stored} stored \n{calculated_digest} calculated, unpacked data not correct!"
+                ));
+        }
+    } else {
+        panic!("We should always have a stored hash signature");
+    }
+    Ok(())
+}
+
+pub fn run_verify(matches: &ArgMatches, output: Arc<Output>) -> Result<()> {
+    let archive_dir = Path::new(matches.get_one::<String>("ARCHIVE").unwrap()).canonicalize()?;
+    let input_file = Path::new(matches.get_one::<String>("INPUT").unwrap()).canonicalize()?;
+
+    env::set_current_dir(archive_dir)?;
+
+    let config = config::read_config(".", matches)?;
+    let cache_nr_entries = (1024 * 1024 * config.data_cache_size_meg) / SLAB_SIZE_TARGET;
+
+    let stream = matches.get_one::<String>("STREAM").unwrap();
+    let stream_cfg = config::read_stream_config(stream)?;
+    let stored_hash = stream_cfg.source_sig;
+
+    let calculated_hash = if matches.get_flag("internal") {
+        run_verify_stream(&stream, output, stream_cfg.size, cache_nr_entries)?
+    } else {
+        run_verify_device_or_file(
+            input_file,
+            output,
+            stream,
+            cache_nr_entries,
+            stream_cfg.size,
+        )?
+    };
+
+    compare_hashes(stored_hash, calculated_hash)?;
+    Ok(())
 }
 
 //-----------------------------------------

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -19,6 +19,17 @@ pub fn is_pow2(v: usize) -> bool {
     v != 0 && ((v & (v - 1)) == 0)
 }
 
+pub fn unmapped_digest_add(hasher: &mut blake3::Hasher, len: u64) {
+    let buf = [0; 4096];
+
+    let mut remaining = len;
+    while remaining > 0 {
+        let hash_len = std::cmp::min(buf.len() as u64, remaining);
+        hasher.update(&buf[0..hash_len as usize]);
+        remaining -= hash_len;
+    }
+}
+
 #[cfg(test)]
 mod util_tests {
 

--- a/tests/common/blk_archive.rs
+++ b/tests/common/blk_archive.rs
@@ -23,6 +23,7 @@ pub struct PackStats {
 pub struct PackResponse {
     pub stream_id: String,
     pub stats: PackStats,
+    pub hash: String,
 }
 
 impl BlkArchive {

--- a/tests/pack.rs
+++ b/tests/pack.rs
@@ -89,7 +89,7 @@ fn pack_random_verify_stats() -> Result<()> {
     let mut rng = rand::thread_rng();
 
     for _ in 0..10 {
-        let r_increase = rng.gen_range(1024..archive::SLAB_SIZE_TARGET);
+        let r_increase = rng.gen_range(1024..archive::file_based::SLAB_SIZE_TARGET);
         let size = file_size_start + r_increase as u64;
 
         pack_common_verify_stats(size, Pattern::LCG)?;
@@ -98,7 +98,7 @@ fn pack_random_verify_stats() -> Result<()> {
     for s in vec![
         file_size_start,
         file_size_start - 10,
-        file_size_start + archive::SLAB_SIZE_TARGET as u64 + 10,
+        file_size_start + archive::file_based::SLAB_SIZE_TARGET as u64 + 10,
     ] {
         pack_common_verify_stats(s, Pattern::LCG)?;
     }


### PR DESCRIPTION
Experiment with coderabbit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Pack now computes and outputs a BLAKE3 digest (hash) and records it in stream metadata.
  - Verify supports an internal-hash mode via --internal (choose between INPUT or internal).
  - Added an alternative Redb-backed storage option for archives.

- Changes
  - Hashing across the app switched to BLAKE3.

- Improvements
  - Unpack and verification perform end-to-end integrity checks using BLAKE3.
  - More robust date parsing in listing; errors are now reported instead of silently proceeding.

- Tests
  - Expanded coverage for deduplication, partial reads, and verification paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->